### PR TITLE
Fix illegal <p> nesting

### DIFF
--- a/_includes/posts.html
+++ b/_includes/posts.html
@@ -15,7 +15,7 @@
             </div>
             <h5 class="card-title big-heading">{{ post.title }}</h5>
             <h6 class="card-subtitle">in {% for category in post.categories %}{{ category }} {% endfor %}</h6>
-            <p class="card-text">{{ post.excerpt }}</p>
+            <div class="card-text">{{ post.excerpt }}</div>
             <span class="card-signature">{{ post.author }}</span>
             <a class="read-more" href="{{ site.baseurl }}{{ post.url }}">
               <span class="text">Leggi di più</span>


### PR DESCRIPTION
The P element represents a paragraph. It cannot contain block-level elements (including P itself), as mentioned [here](https://www.w3.org/TR/html401/struct/text.html).
As such, since the `post.excerpt` is wrapped in a `<p>` tag, I'd suggest to switch the container element to a `<div>`. 
Let me know if that can work.